### PR TITLE
Bug Fixed: Try to remove the zip file twice

### DIFF
--- a/app.py
+++ b/app.py
@@ -237,8 +237,9 @@ _____ __     __   __ ___           ___    __  __  ________ __
                     else:
                         os.remove(filename)
 
-                    os.remove(filename)
-
+                    if os.path.exists(filename):
+                        os.remove(filename)
+                        
                     progress_bar.close()
                 except KeyboardInterrupt:
                     sys.exit()


### PR DESCRIPTION
When the zip file is extracted and no error happens, the zip file is
deleted.

The issue comes when it is deleted again and no exists on disk, raising
an error and forcing to download the same file 5 times.